### PR TITLE
Add responsive OpenAI scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-Test files for greenscore 
+Simple demo for scoring sustainability of a product image using the OpenAI API.
+
+Open `index.html` in a browser. Provide your OpenAI API key, upload an image and
+click **Score product**. The result from the API will be shown on the page.

--- a/app.js
+++ b/app.js
@@ -1,5 +1,6 @@
-document.getElementById('score-btn').addEventListener('click', () => {
+document.getElementById('score-btn').addEventListener('click', async () => {
   const input = document.getElementById('image-input');
+  const apiKeyInput = document.getElementById('api-key');
   const result = document.getElementById('result');
 
   if (!input.files.length) {
@@ -7,6 +8,43 @@ document.getElementById('score-btn').addEventListener('click', () => {
     return;
   }
 
-  const score = Math.floor(Math.random() * 10) + 1;
-  result.textContent = `Estimated sustainability score: ${score}/10`;
+  if (!apiKeyInput.value) {
+    result.textContent = 'Please enter your OpenAI API key.';
+    return;
+  }
+
+  const file = input.files[0];
+  const reader = new FileReader();
+  reader.onloadend = async () => {
+    const base64 = reader.result.split(',')[1];
+    result.textContent = 'Scoring...';
+    try {
+      const resp = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${apiKeyInput.value.trim()}`
+        },
+        body: JSON.stringify({
+          model: 'gpt-4-vision-preview',
+          messages: [
+            {
+              role: 'user',
+              content: [
+                { type: 'text', text: 'Check the green and sustainibilty score of the image uploaded, return all the text description and reason on why the given score.' },
+                { type: 'image_url', image_url: { url: `data:${file.type};base64,${base64}` } }
+              ]
+            }
+          ],
+          max_tokens: 500
+        })
+      });
+      const data = await resp.json();
+      result.textContent = data.choices?.[0]?.message?.content || 'No result';
+    } catch (err) {
+      console.error(err);
+      result.textContent = 'Error contacting OpenAI API.';
+    }
+  };
+  reader.readAsDataURL(file);
 });

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
       <p>Upload a product photo to estimate its environmental impact.</p>
       <div class="scoring" id="score">
         <input type="file" id="image-input" accept="image/*">
+        <input type="text" id="api-key" placeholder="OpenAI API Key">
         <button id="score-btn">Score product</button>
         <p id="result"></p>
       </div>

--- a/style.css
+++ b/style.css
@@ -27,6 +27,21 @@ body {
 .scoring input,
 .scoring button {
   margin-top: 1rem;
+  width: 100%;
+  max-width: 400px;
+}
+
+@media (min-width: 600px) {
+  .scoring input[type="file"],
+  #api-key,
+  .scoring button {
+    width: auto;
+  }
+}
+
+#result {
+  white-space: pre-wrap;
+  margin-top: 1rem;
 }
 
 .footer {


### PR DESCRIPTION
## Summary
- make scoring section responsive
- add API key field
- call OpenAI API with uploaded image and display result
- document basic usage in README

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6853578bf4c4832895f445648ee53668