### PR TITLE
Fix landing page blank screen

### DIFF
--- a/landing-page.js
+++ b/landing-page.js
@@ -1,6 +1,8 @@
-import React, { useState } from "react";
-
-export default function LandingPage() {
+// React is loaded globally via a script tag in index.html. Using the global
+// object here avoids module syntax which isn't supported by the in-browser
+// Babel transform.
+const { useState } = React;
+function LandingPage() {
   const [menuOpen, setMenuOpen] = useState(false);
   const [imagePreview, setImagePreview] = useState(null);
   const [imageFile, setImageFile] = useState(null);


### PR DESCRIPTION
## Summary
- remove ES module syntax so Babel can run in the browser

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6855b57c50648328bf3ae92afe75130b