### PR TITLE
Add mock response for missing API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@ Simple demo for scoring sustainability of a product image using the OpenAI API.
 It uses the `gpt-4o` model, which supports vision input.
 
 Open `index.html` in a browser. Provide your OpenAI API key, upload an image and
-click **Score product**. The result from the API will be shown on the page.
+click **Score product**. If no API key is entered, a mock score and
+description are returned for easy testing. Otherwise, the request is sent to the
+OpenAI API and the result is shown on the page.

--- a/app.js
+++ b/app.js
@@ -1,3 +1,5 @@
+const MOCK_RESULT = `GreenScore: 8/10\nThis is a mock product description used for testing.`;
+
 document.getElementById('score-btn').addEventListener('click', async () => {
   const input = document.getElementById('image-input');
   const apiKeyInput = document.getElementById('api-key');
@@ -8,8 +10,9 @@ document.getElementById('score-btn').addEventListener('click', async () => {
     return;
   }
 
-  if (!apiKeyInput.value) {
-    result.textContent = 'Please enter your OpenAI API key.';
+  if (!apiKeyInput.value.trim()) {
+    // When no API key is provided, show a mocked response for easy testing
+    result.textContent = MOCK_RESULT;
     return;
   }
 

--- a/landing-page.js
+++ b/landing-page.js
@@ -2,6 +2,7 @@
 // object here avoids module syntax which isn't supported by the in-browser
 // Babel transform.
 const { useState } = React;
+const MOCK_RESULT = `GreenScore: 8/10\nThis is a mock product description used for testing.`;
 function LandingPage() {
   const [menuOpen, setMenuOpen] = useState(false);
   const [imagePreview, setImagePreview] = useState(null);
@@ -35,8 +36,9 @@ function LandingPage() {
       setResult("Please select an image first.");
       return;
     }
-    if (!apiKey) {
-      setResult("Please enter your OpenAI API key.");
+    if (!apiKey.trim()) {
+      // Show a mocked result when no API key is provided
+      setResult(MOCK_RESULT);
       return;
     }
 


### PR DESCRIPTION
## Summary
- mock OpenAI result when no API key is provided
- use mock in both demo pages
- document mock behavior in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68571d35be6483289faa0f45428b870f