### PR TITLE
Add responsive navigation to info page

### DIFF
--- a/info.html
+++ b/info.html
@@ -12,14 +12,28 @@
       <img src="assets/Camera%20log.png" alt="EcoSnap logo" class="w-6 h-6" />
       <h1 class="text-xl font-bold text-green-600">EcoSnap</h1>
     </div>
+    <button id="menu-btn" class="md:hidden text-gray-700 focus:outline-none">
+      <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+      </svg>
+    </button>
     <nav class="hidden md:flex gap-6 text-sm font-medium items-center">
       <a href="index.html" class="hover:text-green-600">Home</a>
       <a href="#about" class="hover:text-green-600">About Us</a>
       <a href="#why" class="hover:text-green-600">Why</a>
       <a href="#blog" class="hover:text-green-600">Blog</a>
       <a href="green_agent.html" class="hover:text-green-600">Green Agent</a>
+      <span class="ml-4 text-xs text-gray-500">(5)</span>
     </nav>
   </header>
+  <div id="mobile-menu" class="hidden md:hidden px-6 pb-4 bg-white shadow-sm">
+    <a href="index.html" class="block py-2 text-sm hover:text-green-600">Home</a>
+    <a href="#about" class="block py-2 text-sm hover:text-green-600">About Us</a>
+    <a href="#why" class="block py-2 text-sm hover:text-green-600">Why</a>
+    <a href="#blog" class="block py-2 text-sm hover:text-green-600">Blog</a>
+    <a href="green_agent.html" class="block py-2 text-sm hover:text-green-600">Green Agent</a>
+    <span class="block pt-2 text-xs text-gray-500">(5)</span>
+  </div>
 
   <main>
     <section id="about" class="w-full bg-green-50 py-16 px-8">
@@ -80,5 +94,14 @@
       <p class="text-xs text-gray-500">© 2025 EcoSnap. All rights reserved.</p>
     </div>
   </footer>
+  <script>
+    const menuBtn = document.getElementById('menu-btn');
+    const mobileMenu = document.getElementById('mobile-menu');
+    if (menuBtn && mobileMenu) {
+      menuBtn.addEventListener('click', () => {
+        mobileMenu.classList.toggle('hidden');
+      });
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add hamburger menu and nav links to `info.html`
- include mobile menu toggle script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b18d454a88328ad70dea6c59bc67d