### PR TITLE
Add sustainability analysis page

### DIFF
--- a/analysis.css
+++ b/analysis.css
@@ -1,0 +1,1184 @@
+:root {
+  /* Colors */
+  --color-background: rgba(252, 252, 249, 1);
+  --color-surface: rgba(255, 255, 253, 1);
+  --color-text: rgba(19, 52, 59, 1);
+  --color-text-secondary: rgba(98, 108, 113, 1);
+  --color-primary: rgba(33, 128, 141, 1);
+  --color-primary-hover: rgba(29, 116, 128, 1);
+  --color-primary-active: rgba(26, 104, 115, 1);
+  --color-secondary: rgba(94, 82, 64, 0.12);
+  --color-secondary-hover: rgba(94, 82, 64, 0.2);
+  --color-secondary-active: rgba(94, 82, 64, 0.25);
+  --color-border: rgba(94, 82, 64, 0.2);
+  --color-btn-primary-text: rgba(252, 252, 249, 1);
+  --color-card-border: rgba(94, 82, 64, 0.12);
+  --color-card-border-inner: rgba(94, 82, 64, 0.12);
+  --color-error: rgba(192, 21, 47, 1);
+  --color-success: rgba(33, 128, 141, 1);
+  --color-warning: rgba(168, 75, 47, 1);
+  --color-info: rgba(98, 108, 113, 1);
+  --color-focus-ring: rgba(33, 128, 141, 0.4);
+  --color-select-caret: rgba(19, 52, 59, 0.8);
+
+  /* Common style patterns */
+  --focus-ring: 0 0 0 3px var(--color-focus-ring);
+  --focus-outline: 2px solid var(--color-primary);
+  --status-bg-opacity: 0.15;
+  --status-border-opacity: 0.25;
+  --select-caret-light: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23134252' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  --select-caret-dark: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23f5f5f5' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+
+  /* RGB versions for opacity control */
+  --color-success-rgb: 33, 128, 141;
+  --color-error-rgb: 192, 21, 47;
+  --color-warning-rgb: 168, 75, 47;
+  --color-info-rgb: 98, 108, 113;
+
+  /* Typography */
+  --font-family-base: "FKGroteskNeue", "Geist", "Inter", -apple-system,
+    BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-family-mono: "Berkeley Mono", ui-monospace, SFMono-Regular, Menlo,
+    Monaco, Consolas, monospace;
+  --font-size-xs: 11px;
+  --font-size-sm: 12px;
+  --font-size-base: 14px;
+  --font-size-md: 14px;
+  --font-size-lg: 16px;
+  --font-size-xl: 18px;
+  --font-size-2xl: 20px;
+  --font-size-3xl: 24px;
+  --font-size-4xl: 30px;
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 550;
+  --font-weight-bold: 600;
+  --line-height-tight: 1.2;
+  --line-height-normal: 1.5;
+  --letter-spacing-tight: -0.01em;
+
+  /* Spacing */
+  --space-0: 0;
+  --space-1: 1px;
+  --space-2: 2px;
+  --space-4: 4px;
+  --space-6: 6px;
+  --space-8: 8px;
+  --space-10: 10px;
+  --space-12: 12px;
+  --space-16: 16px;
+  --space-20: 20px;
+  --space-24: 24px;
+  --space-32: 32px;
+
+  /* Border Radius */
+  --radius-sm: 6px;
+  --radius-base: 8px;
+  --radius-md: 10px;
+  --radius-lg: 12px;
+  --radius-full: 9999px;
+
+  /* Shadows */
+  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.02);
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.04), 0 1px 2px rgba(0, 0, 0, 0.02);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.04),
+    0 2px 4px -1px rgba(0, 0, 0, 0.02);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.04),
+    0 4px 6px -2px rgba(0, 0, 0, 0.02);
+  --shadow-inset-sm: inset 0 1px 0 rgba(255, 255, 255, 0.15),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.03);
+
+  /* Animation */
+  --duration-fast: 150ms;
+  --duration-normal: 250ms;
+  --ease-standard: cubic-bezier(0.16, 1, 0.3, 1);
+
+  /* Layout */
+  --container-sm: 640px;
+  --container-md: 768px;
+  --container-lg: 1024px;
+  --container-xl: 1280px;
+}
+
+/* Dark mode colors */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-background: rgba(31, 33, 33, 1);
+    --color-surface: rgba(38, 40, 40, 1);
+    --color-text: rgba(245, 245, 245, 1);
+    --color-text-secondary: rgba(167, 169, 169, 0.7);
+    --color-primary: rgba(50, 184, 198, 1);
+    --color-primary-hover: rgba(45, 166, 178, 1);
+    --color-primary-active: rgba(41, 150, 161, 1);
+    --color-secondary: rgba(119, 124, 124, 0.15);
+    --color-secondary-hover: rgba(119, 124, 124, 0.25);
+    --color-secondary-active: rgba(119, 124, 124, 0.3);
+    --color-border: rgba(119, 124, 124, 0.3);
+    --color-error: rgba(255, 84, 89, 1);
+    --color-success: rgba(50, 184, 198, 1);
+    --color-warning: rgba(230, 129, 97, 1);
+    --color-info: rgba(167, 169, 169, 1);
+    --color-focus-ring: rgba(50, 184, 198, 0.4);
+    --color-btn-primary-text: rgba(19, 52, 59, 1);
+    --color-card-border: rgba(119, 124, 124, 0.2);
+    --color-card-border-inner: rgba(119, 124, 124, 0.15);
+    --shadow-inset-sm: inset 0 1px 0 rgba(255, 255, 255, 0.1),
+      inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+    --button-border-secondary: rgba(119, 124, 124, 0.2);
+    --color-border-secondary: rgba(119, 124, 124, 0.2);
+    --color-select-caret: rgba(245, 245, 245, 0.8);
+
+    /* Common style patterns - updated for dark mode */
+    --focus-ring: 0 0 0 3px var(--color-focus-ring);
+    --focus-outline: 2px solid var(--color-primary);
+    --status-bg-opacity: 0.15;
+    --status-border-opacity: 0.25;
+    --select-caret-light: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23134252' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+    --select-caret-dark: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23f5f5f5' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+
+    /* RGB versions for dark mode */
+    --color-success-rgb: 50, 184, 198;
+    --color-error-rgb: 255, 84, 89;
+    --color-warning-rgb: 230, 129, 97;
+    --color-info-rgb: 167, 169, 169;
+  }
+}
+
+/* Data attribute for manual theme switching */
+[data-color-scheme="dark"] {
+  --color-background: rgba(31, 33, 33, 1);
+  --color-surface: rgba(38, 40, 40, 1);
+  --color-text: rgba(245, 245, 245, 1);
+  --color-text-secondary: rgba(167, 169, 169, 0.7);
+  --color-primary: rgba(50, 184, 198, 1);
+  --color-primary-hover: rgba(45, 166, 178, 1);
+  --color-primary-active: rgba(41, 150, 161, 1);
+  --color-secondary: rgba(119, 124, 124, 0.15);
+  --color-secondary-hover: rgba(119, 124, 124, 0.25);
+  --color-secondary-active: rgba(119, 124, 124, 0.3);
+  --color-border: rgba(119, 124, 124, 0.3);
+  --color-error: rgba(255, 84, 89, 1);
+  --color-success: rgba(50, 184, 198, 1);
+  --color-warning: rgba(230, 129, 97, 1);
+  --color-info: rgba(167, 169, 169, 1);
+  --color-focus-ring: rgba(50, 184, 198, 0.4);
+  --color-btn-primary-text: rgba(19, 52, 59, 1);
+  --color-card-border: rgba(119, 124, 124, 0.15);
+  --color-card-border-inner: rgba(119, 124, 124, 0.15);
+  --shadow-inset-sm: inset 0 1px 0 rgba(255, 255, 255, 0.1),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+  --color-border-secondary: rgba(119, 124, 124, 0.2);
+  --color-select-caret: rgba(245, 245, 245, 0.8);
+
+  /* Common style patterns - updated for dark mode */
+  --focus-ring: 0 0 0 3px var(--color-focus-ring);
+  --focus-outline: 2px solid var(--color-primary);
+  --status-bg-opacity: 0.15;
+  --status-border-opacity: 0.25;
+  --select-caret-light: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23134252' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  --select-caret-dark: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23f5f5f5' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+
+  /* RGB versions for dark mode */
+  --color-success-rgb: 50, 184, 198;
+  --color-error-rgb: 255, 84, 89;
+  --color-warning-rgb: 230, 129, 97;
+  --color-info-rgb: 167, 169, 169;
+}
+
+[data-color-scheme="light"] {
+  --color-background: rgba(252, 252, 249, 1);
+  --color-surface: rgba(255, 255, 253, 1);
+  --color-text: rgba(19, 52, 59, 1);
+  --color-text-secondary: rgba(98, 108, 113, 1);
+  --color-primary: rgba(33, 128, 141, 1);
+  --color-primary-hover: rgba(29, 116, 128, 1);
+  --color-primary-active: rgba(26, 104, 115, 1);
+  --color-secondary: rgba(94, 82, 64, 0.12);
+  --color-secondary-hover: rgba(94, 82, 64, 0.2);
+  --color-secondary-active: rgba(94, 82, 64, 0.25);
+  --color-border: rgba(94, 82, 64, 0.2);
+  --color-btn-primary-text: rgba(252, 252, 249, 1);
+  --color-card-border: rgba(94, 82, 64, 0.12);
+  --color-card-border-inner: rgba(94, 82, 64, 0.12);
+  --color-error: rgba(192, 21, 47, 1);
+  --color-success: rgba(33, 128, 141, 1);
+  --color-warning: rgba(168, 75, 47, 1);
+  --color-info: rgba(98, 108, 113, 1);
+  --color-focus-ring: rgba(33, 128, 141, 0.4);
+
+  /* RGB versions for light mode */
+  --color-success-rgb: 33, 128, 141;
+  --color-error-rgb: 192, 21, 47;
+  --color-warning-rgb: 168, 75, 47;
+  --color-info-rgb: 98, 108, 113;
+}
+
+/* Base styles */
+html {
+  font-size: var(--font-size-base);
+  font-family: var(--font-family-base);
+  line-height: var(--line-height-normal);
+  color: var(--color-text);
+  background-color: var(--color-background);
+  -webkit-font-smoothing: antialiased;
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+
+/* Typography */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0;
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--line-height-tight);
+  color: var(--color-text);
+  letter-spacing: var(--letter-spacing-tight);
+}
+
+h1 {
+  font-size: var(--font-size-4xl);
+}
+h2 {
+  font-size: var(--font-size-3xl);
+}
+h3 {
+  font-size: var(--font-size-2xl);
+}
+h4 {
+  font-size: var(--font-size-xl);
+}
+h5 {
+  font-size: var(--font-size-lg);
+}
+h6 {
+  font-size: var(--font-size-md);
+}
+
+p {
+  margin: 0 0 var(--space-16) 0;
+}
+
+a {
+  color: var(--color-primary);
+  text-decoration: none;
+  transition: color var(--duration-fast) var(--ease-standard);
+}
+
+a:hover {
+  color: var(--color-primary-hover);
+}
+
+code,
+pre {
+  font-family: var(--font-family-mono);
+  font-size: calc(var(--font-size-base) * 0.95);
+  background-color: var(--color-secondary);
+  border-radius: var(--radius-sm);
+}
+
+code {
+  padding: var(--space-1) var(--space-4);
+}
+
+pre {
+  padding: var(--space-16);
+  margin: var(--space-16) 0;
+  overflow: auto;
+  border: 1px solid var(--color-border);
+}
+
+pre code {
+  background: none;
+  padding: 0;
+}
+
+/* Buttons */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-8) var(--space-16);
+  border-radius: var(--radius-base);
+  font-size: var(--font-size-base);
+  font-weight: 500;
+  line-height: 1.5;
+  cursor: pointer;
+  transition: all var(--duration-normal) var(--ease-standard);
+  border: none;
+  text-decoration: none;
+  position: relative;
+}
+
+.btn:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.btn--primary {
+  background: var(--color-primary);
+  color: var(--color-btn-primary-text);
+}
+
+.btn--primary:hover {
+  background: var(--color-primary-hover);
+}
+
+.btn--primary:active {
+  background: var(--color-primary-active);
+}
+
+.btn--secondary {
+  background: var(--color-secondary);
+  color: var(--color-text);
+}
+
+.btn--secondary:hover {
+  background: var(--color-secondary-hover);
+}
+
+.btn--secondary:active {
+  background: var(--color-secondary-active);
+}
+
+.btn--outline {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+}
+
+.btn--outline:hover {
+  background: var(--color-secondary);
+}
+
+.btn--sm {
+  padding: var(--space-4) var(--space-12);
+  font-size: var(--font-size-sm);
+  border-radius: var(--radius-sm);
+}
+
+.btn--lg {
+  padding: var(--space-10) var(--space-20);
+  font-size: var(--font-size-lg);
+  border-radius: var(--radius-md);
+}
+
+.btn--full-width {
+  width: 100%;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Form elements */
+.form-control {
+  display: block;
+  width: 100%;
+  padding: var(--space-8) var(--space-12);
+  font-size: var(--font-size-md);
+  line-height: 1.5;
+  color: var(--color-text);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-base);
+  transition: border-color var(--duration-fast) var(--ease-standard),
+    box-shadow var(--duration-fast) var(--ease-standard);
+}
+
+textarea.form-control {
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-base);
+}
+
+select.form-control {
+  padding: var(--space-8) var(--space-12);
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-image: var(--select-caret-light);
+  background-repeat: no-repeat;
+  background-position: right var(--space-12) center;
+  background-size: 16px;
+  padding-right: var(--space-32);
+}
+
+/* Add a dark mode specific caret */
+@media (prefers-color-scheme: dark) {
+  select.form-control {
+    background-image: var(--select-caret-dark);
+  }
+}
+
+/* Also handle data-color-scheme */
+[data-color-scheme="dark"] select.form-control {
+  background-image: var(--select-caret-dark);
+}
+
+[data-color-scheme="light"] select.form-control {
+  background-image: var(--select-caret-light);
+}
+
+.form-control:focus {
+  border-color: var(--color-primary);
+  outline: var(--focus-outline);
+}
+
+.form-label {
+  display: block;
+  margin-bottom: var(--space-8);
+  font-weight: var(--font-weight-medium);
+  font-size: var(--font-size-sm);
+}
+
+.form-group {
+  margin-bottom: var(--space-16);
+}
+
+/* Card component */
+.card {
+  background-color: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-card-border);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+  transition: box-shadow var(--duration-normal) var(--ease-standard);
+}
+
+.card:hover {
+  box-shadow: var(--shadow-md);
+}
+
+.card__body {
+  padding: var(--space-16);
+}
+
+.card__header,
+.card__footer {
+  padding: var(--space-16);
+  border-bottom: 1px solid var(--color-card-border-inner);
+}
+
+/* Status indicators - simplified with CSS variables */
+.status {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-6) var(--space-12);
+  border-radius: var(--radius-full);
+  font-weight: var(--font-weight-medium);
+  font-size: var(--font-size-sm);
+}
+
+.status--success {
+  background-color: rgba(
+    var(--color-success-rgb, 33, 128, 141),
+    var(--status-bg-opacity)
+  );
+  color: var(--color-success);
+  border: 1px solid
+    rgba(var(--color-success-rgb, 33, 128, 141), var(--status-border-opacity));
+}
+
+.status--error {
+  background-color: rgba(
+    var(--color-error-rgb, 192, 21, 47),
+    var(--status-bg-opacity)
+  );
+  color: var(--color-error);
+  border: 1px solid
+    rgba(var(--color-error-rgb, 192, 21, 47), var(--status-border-opacity));
+}
+
+.status--warning {
+  background-color: rgba(
+    var(--color-warning-rgb, 168, 75, 47),
+    var(--status-bg-opacity)
+  );
+  color: var(--color-warning);
+  border: 1px solid
+    rgba(var(--color-warning-rgb, 168, 75, 47), var(--status-border-opacity));
+}
+
+.status--info {
+  background-color: rgba(
+    var(--color-info-rgb, 98, 108, 113),
+    var(--status-bg-opacity)
+  );
+  color: var(--color-info);
+  border: 1px solid
+    rgba(var(--color-info-rgb, 98, 108, 113), var(--status-border-opacity));
+}
+
+/* Container layout */
+.container {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--space-16);
+  padding-left: var(--space-16);
+}
+
+@media (min-width: 640px) {
+  .container {
+    max-width: var(--container-sm);
+  }
+}
+@media (min-width: 768px) {
+  .container {
+    max-width: var(--container-md);
+  }
+}
+@media (min-width: 1024px) {
+  .container {
+    max-width: var(--container-lg);
+  }
+}
+@media (min-width: 1280px) {
+  .container {
+    max-width: var(--container-xl);
+  }
+}
+
+/* Utility classes */
+.flex {
+  display: flex;
+}
+.flex-col {
+  flex-direction: column;
+}
+.items-center {
+  align-items: center;
+}
+.justify-center {
+  justify-content: center;
+}
+.justify-between {
+  justify-content: space-between;
+}
+.gap-4 {
+  gap: var(--space-4);
+}
+.gap-8 {
+  gap: var(--space-8);
+}
+.gap-16 {
+  gap: var(--space-16);
+}
+
+.m-0 {
+  margin: 0;
+}
+.mt-8 {
+  margin-top: var(--space-8);
+}
+.mb-8 {
+  margin-bottom: var(--space-8);
+}
+.mx-8 {
+  margin-left: var(--space-8);
+  margin-right: var(--space-8);
+}
+.my-8 {
+  margin-top: var(--space-8);
+  margin-bottom: var(--space-8);
+}
+
+.p-0 {
+  padding: 0;
+}
+.py-8 {
+  padding-top: var(--space-8);
+  padding-bottom: var(--space-8);
+}
+.px-8 {
+  padding-left: var(--space-8);
+  padding-right: var(--space-8);
+}
+.py-16 {
+  padding-top: var(--space-16);
+  padding-bottom: var(--space-16);
+}
+.px-16 {
+  padding-left: var(--space-16);
+  padding-right: var(--space-16);
+}
+
+.block {
+  display: block;
+}
+.hidden {
+  display: none;
+}
+
+/* Accessibility */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+:focus-visible {
+  outline: var(--focus-outline);
+  outline-offset: 2px;
+}
+
+/* Dark mode specifics */
+[data-color-scheme="dark"] .btn--outline {
+  border: 1px solid var(--color-border-secondary);
+}
+
+@font-face {
+  font-family: 'FKGroteskNeue';
+  src: url('https://r2cdn.perplexity.ai/fonts/FKGroteskNeue.woff2')
+    format('woff2');
+}
+
+/* Custom styles for Sustainability Dashboard */
+
+/* Header Section */
+.header {
+  text-align: center;
+  margin-bottom: var(--space-32);
+  padding: var(--space-32) 0;
+}
+
+.header h1 {
+  font-size: var(--font-size-4xl);
+  color: var(--color-text);
+  margin-bottom: var(--space-12);
+  font-weight: var(--font-weight-bold);
+}
+
+.header .subtitle {
+  font-size: var(--font-size-2xl);
+  color: var(--color-primary);
+  margin-bottom: var(--space-20);
+  font-weight: var(--font-weight-medium);
+}
+
+.header .intro {
+  font-size: var(--font-size-lg);
+  color: var(--color-text-secondary);
+  line-height: var(--line-height-normal);
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+/* Score Section */
+.score-section {
+  margin-bottom: var(--space-32);
+  text-align: center;
+  padding: var(--space-32);
+  background: linear-gradient(135deg, var(--color-surface) 0%, rgba(33, 128, 141, 0.05) 100%);
+}
+
+.score-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.score-display {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: var(--space-16);
+  gap: var(--space-8);
+}
+
+.score-number {
+  font-size: 4rem;
+  font-weight: var(--font-weight-bold);
+  color: #f59e0b;
+  line-height: 1;
+}
+
+.score-divider {
+  font-size: 3rem;
+  color: var(--color-text-secondary);
+  opacity: 0.5;
+}
+
+.score-max {
+  font-size: 2rem;
+  color: var(--color-text-secondary);
+  line-height: 1;
+}
+
+.score-label {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+  margin-bottom: var(--space-20);
+}
+
+.score-progress {
+  margin-bottom: var(--space-24);
+}
+
+.progress-bar {
+  width: 100%;
+  height: 12px;
+  background-color: var(--color-secondary);
+  border-radius: var(--radius-full);
+  overflow: hidden;
+  margin-bottom: var(--space-12);
+  position: relative;
+}
+
+.progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #ef4444 0%, #f59e0b 50%, #22c55e 100%);
+  border-radius: var(--radius-full);
+  width: 70%;
+  transition: width var(--duration-normal) var(--ease-standard);
+}
+
+.score-zones {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+}
+
+.zone {
+  padding: var(--space-4) var(--space-8);
+  border-radius: var(--radius-base);
+}
+
+.zone-red {
+  background-color: rgba(239, 68, 68, 0.1);
+  color: #dc2626;
+}
+
+.zone-yellow {
+  background-color: rgba(245, 158, 11, 0.1);
+  color: #d97706;
+}
+
+.zone-green {
+  background-color: rgba(34, 197, 94, 0.1);
+  color: #16a34a;
+}
+
+.score-rationale {
+  font-size: var(--font-size-base);
+  color: var(--color-text-secondary);
+  line-height: var(--line-height-normal);
+  text-align: left;
+}
+
+/* Analysis Sections */
+.analysis-sections {
+  margin-bottom: var(--space-32);
+}
+
+.analysis-sections h3 {
+  font-size: var(--font-size-3xl);
+  color: var(--color-text);
+  margin-bottom: var(--space-24);
+  text-align: center;
+}
+
+.analysis-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: var(--space-20);
+}
+
+.analysis-card {
+  transition: all var(--duration-normal) var(--ease-standard);
+  cursor: pointer;
+  overflow: hidden;
+}
+
+.analysis-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg);
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-16);
+  padding: var(--space-20);
+  border-bottom: 1px solid var(--color-card-border-inner);
+  background-color: var(--color-surface);
+}
+
+.card-icon {
+  font-size: 2rem;
+  flex-shrink: 0;
+}
+
+.card-title {
+  flex-grow: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-16);
+}
+
+.card-title h4 {
+  font-size: var(--font-size-lg);
+  color: var(--color-text);
+  margin: 0;
+}
+
+.section-score {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+  flex-shrink: 0;
+}
+
+.score-value {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text);
+  min-width: 24px;
+}
+
+.score-bar {
+  width: 60px;
+  height: 6px;
+  background-color: var(--color-secondary);
+  border-radius: var(--radius-full);
+  overflow: hidden;
+}
+
+.score-bar-fill {
+  height: 100%;
+  border-radius: var(--radius-full);
+  transition: width var(--duration-normal) var(--ease-standard);
+}
+
+.score-bar-fill[data-score="5"] { width: 50%; background-color: #f59e0b; }
+.score-bar-fill[data-score="6"] { width: 60%; background-color: #f59e0b; }
+.score-bar-fill[data-score="7"] { width: 70%; background-color: #f59e0b; }
+.score-bar-fill[data-score="8"] { width: 80%; background-color: #22c55e; }
+.score-bar-fill[data-score="9"] { width: 90%; background-color: #22c55e; }
+
+.expand-btn {
+  background: none;
+  border: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  padding: var(--space-4);
+  border-radius: var(--radius-base);
+  transition: all var(--duration-fast) var(--ease-standard);
+  flex-shrink: 0;
+}
+
+.expand-btn:hover {
+  background-color: var(--color-secondary);
+  color: var(--color-text);
+}
+
+.expand-btn svg {
+  transition: transform var(--duration-fast) var(--ease-standard);
+}
+
+.analysis-card.expanded .expand-btn svg {
+  transform: rotate(180deg);
+}
+
+.card-content {
+  padding: 0 var(--space-20) var(--space-20);
+  max-height: 0;
+  overflow: hidden;
+  transition: all var(--duration-normal) var(--ease-standard);
+  opacity: 0;
+}
+
+.analysis-card.expanded .card-content {
+  max-height: 500px;
+  opacity: 1;
+  padding: var(--space-20);
+}
+
+.assumption, .evaluation {
+  margin-bottom: var(--space-16);
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-normal);
+}
+
+.assumption {
+  color: var(--color-text-secondary);
+  padding: var(--space-12);
+  background-color: var(--color-secondary);
+  border-radius: var(--radius-base);
+  border-left: 3px solid var(--color-info);
+}
+
+.evaluation {
+  color: var(--color-text);
+  padding: var(--space-12);
+  background-color: rgba(33, 128, 141, 0.05);
+  border-radius: var(--radius-base);
+  border-left: 3px solid var(--color-primary);
+}
+
+.key-points {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.key-points li {
+  padding: var(--space-8) 0;
+  border-bottom: 1px solid var(--color-card-border-inner);
+  position: relative;
+  padding-left: var(--space-20);
+  color: var(--color-text);
+}
+
+.key-points li:last-child {
+  border-bottom: none;
+}
+
+.key-points li::before {
+  content: "•";
+  color: var(--color-primary);
+  position: absolute;
+  left: 0;
+  font-weight: var(--font-weight-bold);
+}
+
+/* Insights Section */
+.insights-section {
+  margin-bottom: var(--space-32);
+}
+
+.insights-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: var(--space-20);
+}
+
+.insights-card {
+  padding: var(--space-24);
+}
+
+.insights-card h3 {
+  font-size: var(--font-size-xl);
+  margin-bottom: var(--space-16);
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+}
+
+.strengths {
+  border-left: 4px solid #22c55e;
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.05) 0%, var(--color-surface) 100%);
+}
+
+.strengths h3 {
+  color: #16a34a;
+}
+
+.strengths h3::before {
+  content: "✓";
+  font-weight: var(--font-weight-bold);
+  color: #22c55e;
+}
+
+.improvements {
+  border-left: 4px solid #f59e0b;
+  background: linear-gradient(135deg, rgba(245, 158, 11, 0.05) 0%, var(--color-surface) 100%);
+}
+
+.improvements h3 {
+  color: #d97706;
+}
+
+.improvements h3::before {
+  content: "⚡";
+  font-weight: var(--font-weight-bold);
+  color: #f59e0b;
+}
+
+.insights-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.insights-card li {
+  padding: var(--space-10) 0;
+  border-bottom: 1px solid var(--color-card-border-inner);
+  position: relative;
+  padding-left: var(--space-20);
+  color: var(--color-text);
+  line-height: var(--line-height-normal);
+}
+
+.insights-card li:last-child {
+  border-bottom: none;
+}
+
+.strengths li::before {
+  content: "→";
+  color: #22c55e;
+  position: absolute;
+  left: 0;
+  font-weight: var(--font-weight-bold);
+}
+
+.improvements li::before {
+  content: "→";
+  color: #f59e0b;
+  position: absolute;
+  left: 0;
+  font-weight: var(--font-weight-bold);
+}
+
+/* Footer */
+.footer {
+  margin-top: var(--space-32);
+  padding: var(--space-32) 0;
+  border-top: 1px solid var(--color-border);
+  background-color: var(--color-secondary);
+}
+
+.methodology {
+  text-align: center;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.methodology h4 {
+  font-size: var(--font-size-xl);
+  color: var(--color-text);
+  margin-bottom: var(--space-16);
+}
+
+.methodology p {
+  font-size: var(--font-size-base);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-8);
+  line-height: var(--line-height-normal);
+}
+
+.methodology p:last-child {
+  margin-bottom: 0;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .header {
+    padding: var(--space-20) 0;
+  }
+  
+  .header h1 {
+    font-size: var(--font-size-3xl);
+  }
+  
+  .header .subtitle {
+    font-size: var(--font-size-xl);
+  }
+  
+  .score-number {
+    font-size: 3rem;
+  }
+  
+  .score-divider {
+    font-size: 2rem;
+  }
+  
+  .score-max {
+    font-size: 1.5rem;
+  }
+  
+  .analysis-grid {
+    grid-template-columns: 1fr;
+    gap: var(--space-16);
+  }
+  
+  .insights-grid {
+    grid-template-columns: 1fr;
+    gap: var(--space-16);
+  }
+  
+  .card-header {
+    padding: var(--space-16);
+  }
+  
+  .card-title {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-8);
+  }
+  
+  .section-score {
+    align-self: flex-end;
+  }
+}
+
+@media (max-width: 480px) {
+  .container {
+    padding-left: var(--space-12);
+    padding-right: var(--space-12);
+  }
+  
+  .score-section {
+    padding: var(--space-20);
+  }
+  
+  .card-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-12);
+  }
+  
+  .card-title {
+    width: 100%;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+}
+
+/* Animation for score progress */
+@keyframes fillProgress {
+  from {
+    width: 0;
+  }
+  to {
+    width: var(--target-width, 70%);
+  }
+}
+
+.progress-fill {
+  animation: fillProgress 1.5s var(--ease-standard) 0.5s both;
+}
+
+/* Focus states for accessibility */
+.analysis-card:focus-visible {
+  outline: var(--focus-outline);
+  outline-offset: 2px;
+}
+
+.expand-btn:focus-visible {
+  outline: var(--focus-outline);
+  outline-offset: 2px;
+}

--- a/analysis.html
+++ b/analysis.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Product Sustainability Analysis - Stainless Steel Tumbler</title>
+    <link rel="stylesheet" href="analysis.css">
+</head>
+<body>
+    <div class="container">
+        <!-- Header Section -->
+        <header class="header">
+            <h1>Product Sustainability Analysis</h1>
+            <h2 class="subtitle">Stainless Steel Tumbler</h2>
+            <p class="intro">
+                Comprehensive environmental impact assessment evaluating materials, manufacturing, design, and end-of-life considerations to determine the overall sustainability performance of this reusable drinkware product.
+            </p>
+        </header>
+
+        <!-- Overall Score Section -->
+        <section class="score-section card">
+            <div class="score-container">
+                <div class="score-display">
+                    <div class="score-number">7</div>
+                    <div class="score-divider">/</div>
+                    <div class="score-max">10</div>
+                </div>
+                <div class="score-label">GreenScore</div>
+                <div class="score-progress">
+                    <div class="progress-bar">
+                        <div class="progress-fill" data-score="7"></div>
+                    </div>
+                    <div class="score-zones">
+                        <span class="zone zone-red">1-4</span>
+                        <span class="zone zone-yellow">5-7</span>
+                        <span class="zone zone-green">8-10</span>
+                    </div>
+                </div>
+                <p class="score-rationale">
+                    The product appears to use durable materials and has the potential for positive end-of-life outcomes through recyclability. However, due to assumptions about manufacturing processes and finishings, a score of 7 reflects a moderately sustainable product, with room for improvement in material sourcing and processes.
+                </p>
+            </div>
+        </section>
+
+        <!-- Analysis Sections -->
+        <section class="analysis-sections">
+            <h3>Detailed Analysis</h3>
+            <div class="analysis-grid">
+                <div class="analysis-card card" data-section="materials">
+                    <div class="card-header">
+                        <div class="card-icon">🏗️</div>
+                        <div class="card-title">
+                            <h4>Materials</h4>
+                            <div class="section-score">
+                                <span class="score-value">8</span>
+                                <div class="score-bar">
+                                    <div class="score-bar-fill" data-score="8"></div>
+                                </div>
+                            </div>
+                        </div>
+                        <button class="expand-btn" aria-label="Expand Materials section">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <polyline points="6 9 12 15 18 9"></polyline>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="card-content">
+                        <div class="assumption">
+                            <strong>Assumption:</strong> The tumbler appears to be made of stainless steel with a plastic lid and straw.
+                        </div>
+                        <div class="evaluation">
+                            <strong>Evaluation:</strong> Stainless steel is a durable and recyclable material. If the plastic used is recyclable, it adds to the sustainability.
+                        </div>
+                        <ul class="key-points">
+                            <li>Stainless steel: 100% recyclable</li>
+                            <li>High durability reduces replacement needs</li>
+                            <li>Plastic components: recyclability uncertain</li>
+                        </ul>
+                    </div>
+                </div>
+
+                <div class="analysis-card card" data-section="manufacturing">
+                    <div class="card-header">
+                        <div class="card-icon">⚙️</div>
+                        <div class="card-title">
+                            <h4>Manufacturing Process</h4>
+                            <div class="section-score">
+                                <span class="score-value">6</span>
+                                <div class="score-bar">
+                                    <div class="score-bar-fill" data-score="6"></div>
+                                </div>
+                            </div>
+                        </div>
+                        <button class="expand-btn" aria-label="Expand Manufacturing Process section">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <polyline points="6 9 12 15 18 9"></polyline>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="card-content">
+                        <div class="assumption">
+                            <strong>Assumption:</strong> Without specific details, it is assumed that the manufacturing process follows standard industry techniques, likely involving some energy consumption but not necessarily energy-efficient methods.
+                        </div>
+                        <div class="evaluation">
+                            <strong>Evaluation:</strong> If the product is designed to be durable and recyclable, it might offset some of the environmental impact from manufacturing.
+                        </div>
+                        <ul class="key-points">
+                            <li>Standard industry manufacturing assumed</li>
+                            <li>Energy consumption during production</li>
+                            <li>Durability may offset manufacturing impact</li>
+                        </ul>
+                    </div>
+                </div>
+
+                <div class="analysis-card card" data-section="design">
+                    <div class="card-header">
+                        <div class="card-icon">🔧</div>
+                        <div class="card-title">
+                            <h4>Design and Durability</h4>
+                            <div class="section-score">
+                                <span class="score-value">8</span>
+                                <div class="score-bar">
+                                    <div class="score-bar-fill" data-score="8"></div>
+                                </div>
+                            </div>
+                        </div>
+                        <button class="expand-btn" aria-label="Expand Design and Durability section">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <polyline points="6 9 12 15 18 9"></polyline>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="card-content">
+                        <div class="assumption">
+                            <strong>Assumption:</strong> The design seems practical with a focus on functionality, indicating potential durability and longevity. However, moderation in design is assumed without specific details.
+                        </div>
+                        <div class="evaluation">
+                            <strong>Evaluation:</strong> A durable design supports sustainability by reducing the need for frequent replacements.
+                        </div>
+                        <ul class="key-points">
+                            <li>Practical, functional design</li>
+                            <li>Built for longevity</li>
+                            <li>Reduces replacement frequency</li>
+                        </ul>
+                    </div>
+                </div>
+
+                <div class="analysis-card card" data-section="finishing">
+                    <div class="card-header">
+                        <div class="card-icon">🎨</div>
+                        <div class="card-title">
+                            <h4>Finishing and Coatings</h4>
+                            <div class="section-score">
+                                <span class="score-value">5</span>
+                                <div class="score-bar">
+                                    <div class="score-bar-fill" data-score="5"></div>
+                                </div>
+                            </div>
+                        </div>
+                        <button class="expand-btn" aria-label="Expand Finishing and Coatings section">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <polyline points="6 9 12 15 18 9"></polyline>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="card-content">
+                        <div class="assumption">
+                            <strong>Assumption:</strong> It's unclear from the image if the finishes are eco-friendly, so standard finishes are assumed.
+                        </div>
+                        <div class="evaluation">
+                            <strong>Evaluation:</strong> Non-toxic finishes would significantly enhance sustainability but cannot be confirmed without more details.
+                        </div>
+                        <ul class="key-points">
+                            <li>Finish type unclear</li>
+                            <li>Standard coatings assumed</li>
+                            <li>Eco-friendly finishes would improve score</li>
+                        </ul>
+                    </div>
+                </div>
+
+                <div class="analysis-card card" data-section="endoflife">
+                    <div class="card-header">
+                        <div class="card-icon">♻️</div>
+                        <div class="card-title">
+                            <h4>End of Life</h4>
+                            <div class="section-score">
+                                <span class="score-value">9</span>
+                                <div class="score-bar">
+                                    <div class="score-bar-fill" data-score="9"></div>
+                                </div>
+                            </div>
+                        </div>
+                        <button class="expand-btn" aria-label="Expand End of Life section">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <polyline points="6 9 12 15 18 9"></polyline>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="card-content">
+                        <div class="assumption">
+                            <strong>Assumption:</strong> Assuming the materials are typically recyclable, especially stainless steel and possibly the plastic parts.
+                        </div>
+                        <div class="evaluation">
+                            <strong>Evaluation:</strong> If designed for recyclability, this can significantly reduce waste at the product's end of life.
+                        </div>
+                        <ul class="key-points">
+                            <li>Stainless steel: fully recyclable</li>
+                            <li>Minimal waste generation</li>
+                            <li>Supports circular economy</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Key Insights Panel -->
+        <section class="insights-section">
+            <div class="insights-grid">
+                <div class="insights-card card strengths">
+                    <h3>Key Strengths</h3>
+                    <ul>
+                        <li>Highly durable materials reduce replacement needs</li>
+                        <li>Excellent recyclability of stainless steel components</li>
+                        <li>Replaces hundreds of single-use cups over lifetime</li>
+                        <li>Supports circular economy principles</li>
+                    </ul>
+                </div>
+                <div class="insights-card card improvements">
+                    <h3>Areas for Improvement</h3>
+                    <ul>
+                        <li>Verify plastic component recyclability</li>
+                        <li>Consider eco-friendly finish options</li>
+                        <li>Optimize manufacturing energy efficiency</li>
+                        <li>Provide recycling guidance to users</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <!-- Footer -->
+        <footer class="footer">
+            <div class="methodology">
+                <h4>Assessment Methodology</h4>
+                <p><strong>Framework:</strong> Life Cycle Assessment (LCA) approach</p>
+                <p><strong>Scope:</strong> Pre-manufacturing to end-of-life</p>
+                <p><strong>Scoring System:</strong> 10-point scale (1=Poor, 10=Excellent)</p>
+                <p><strong>Assessment Date:</strong> June 2025</p>
+            </div>
+        </footer>
+    </div>
+
+    <script src="analysis.js"></script>
+</body>
+</html>

--- a/landing-page.js
+++ b/landing-page.js
@@ -37,9 +37,15 @@ function LandingPage() {
       setResult("Please select an image first.");
       return;
     }
+
+    const finalize = (text) => {
+      setResult(text);
+      sessionStorage.setItem('analysisResult', text);
+      window.location.href = 'analysis.html';
+    };
+
     if (!apiKey.trim()) {
-      // Show a mocked result when no API key is provided
-      setResult(MOCK_RESULT);
+      finalize(MOCK_RESULT);
       return;
     }
 
@@ -84,14 +90,14 @@ GreenScore: Provide an estimated GreenScore (0-10) based on these factors, deriv
         });
           const data = await resp.json();
           if (!resp.ok) {
-            setResult(data.error?.message || 'Error contacting OpenAI API.');
+            finalize(data.error?.message || 'Error contacting OpenAI API.');
           } else {
             const text = data.choices?.[0]?.message?.content || 'No result';
-            setResult(text);
+            finalize(text);
           }
         } catch (err) {
           console.error(err);
-          setResult('Error contacting OpenAI API.');
+          finalize('Error contacting OpenAI API.');
         }
       };
       reader.readAsDataURL(imageFile);


### PR DESCRIPTION
## Summary
- implement new sustainability analysis page using provided HTML/CSS/JS
- redirect to analysis page when scoring completes
- store API result in sessionStorage to populate analysis page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685b1a675a3883289d3327c1aa097789