### PR TITLE
Display API output for debugging

### DIFF
--- a/analysis.html
+++ b/analysis.html
@@ -50,6 +50,14 @@
             </div>
         </section>
 
+        <section class="api-debug card">
+            <h3>Debug Info</h3>
+            <label for="raw-response">Raw OpenAI Response</label>
+            <textarea id="raw-response" class="form-control api-raw" rows="6" readonly></textarea>
+            <label for="parsed-response">Parsed Result</label>
+            <textarea id="parsed-response" class="form-control api-parsed" rows="6" readonly></textarea>
+        </section>
+
         <!-- Analysis Sections -->
         <section class="analysis-sections">
             <h3>Detailed Analysis</h3>

--- a/analysis.js
+++ b/analysis.js
@@ -216,6 +216,12 @@ document.addEventListener('DOMContentLoaded', function() {
     const stored = sessionStorage.getItem('analysisResult');
     if (stored) {
         const parsed = parseAnalysisText(stored);
+        console.log('OpenAI raw result:', stored);
+        console.log('Parsed result:', parsed);
+        const rawBox = document.getElementById('raw-response');
+        if (rawBox) rawBox.value = stored;
+        const parsedBox = document.getElementById('parsed-response');
+        if (parsedBox) parsedBox.value = JSON.stringify(parsed, null, 2);
         const rationale = document.querySelector('.score-rationale');
         if (rationale) rationale.textContent = parsed.rationale || stored;
         if (parsed.score) {


### PR DESCRIPTION
## Summary
- add a debug section below the score meter
- log the raw OpenAI response and parsed result
- show both values in text areas for easier troubleshooting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b3dc9995883289e557c5d5dcede46