### PR TITLE
Fix debug parsing issue

### DIFF
--- a/analysis.js
+++ b/analysis.js
@@ -348,20 +348,27 @@ function parseAnalysisText(text) {
             return;
         }
         if (lower.startsWith('rationale')) {
-            current = 'rationale';
             sections.rationale = trimmed.replace(/^rationale\s*:?\s*/i, '');
+            current = 'rationale';
             return;
         }
 
         if (current) {
+            if (current === 'rationale') {
+                sections.rationale = (sections.rationale ? sections.rationale + ' ' : '') + trimmed;
+                return;
+            }
             if (/^\*?assumption\*?/i.test(trimmed)) {
+                if (!sections[current]) sections[current] = {};
                 sections[current].assumption = trimmed.replace(/^\*?assumption\*?\s*:?\s*/i, '');
                 return;
             }
             if (/^\*?evaluation\*?/i.test(trimmed)) {
+                if (!sections[current]) sections[current] = {};
                 sections[current].evaluation = trimmed.replace(/^\*?evaluation\*?\s*:?\s*/i, '');
                 return;
             }
+            if (!sections[current]) sections[current] = {};
             sections[current].extra = (sections[current].extra ? sections[current].extra + ' ' : '') + trimmed;
         }
     });


### PR DESCRIPTION
## Summary
- fix `parseAnalysisText` to handle GreenScore rationale correctly

## Testing
- `node` script to parse sample text

------
https://chatgpt.com/codex/tasks/task_e_685b40f2fd9c83289c2474136332c413