### PR TITLE
Fix analysis UI to display extra info

### DIFF
--- a/analysis.css
+++ b/analysis.css
@@ -916,7 +916,7 @@ select.form-control {
   padding: var(--space-20);
 }
 
-.assumption, .evaluation {
+.assumption, .evaluation, .extra {
   margin-bottom: var(--space-16);
   font-size: var(--font-size-base);
   line-height: var(--line-height-normal);
@@ -936,6 +936,14 @@ select.form-control {
   background-color: rgba(33, 128, 141, 0.05);
   border-radius: var(--radius-base);
   border-left: 3px solid var(--color-primary);
+}
+
+.extra {
+  color: var(--color-text-secondary);
+  padding: var(--space-12);
+  background-color: var(--color-secondary);
+  border-radius: var(--radius-base);
+  border-left: 3px solid var(--color-card-border);
 }
 
 .key-points {

--- a/analysis.html
+++ b/analysis.html
@@ -83,6 +83,7 @@
                     <div class="card-content">
                         <div class="assumption"></div>
                         <div class="evaluation"></div>
+                        <div class="extra"></div>
                     </div>
                 </div>
 
@@ -107,6 +108,7 @@
                     <div class="card-content">
                         <div class="assumption"></div>
                         <div class="evaluation"></div>
+                        <div class="extra"></div>
                     </div>
                 </div>
 
@@ -131,6 +133,7 @@
                     <div class="card-content">
                         <div class="assumption"></div>
                         <div class="evaluation"></div>
+                        <div class="extra"></div>
                     </div>
                 </div>
 
@@ -155,6 +158,7 @@
                     <div class="card-content">
                         <div class="assumption"></div>
                         <div class="evaluation"></div>
+                        <div class="extra"></div>
                     </div>
                 </div>
 
@@ -179,6 +183,7 @@
                     <div class="card-content">
                         <div class="assumption"></div>
                         <div class="evaluation"></div>
+                        <div class="extra"></div>
                     </div>
                 </div>
             </div>

--- a/analysis.js
+++ b/analysis.js
@@ -239,11 +239,15 @@ document.addEventListener('DOMContentLoaded', function() {
                 if (card) {
                     const a = card.querySelector('.assumption');
                     const e = card.querySelector('.evaluation');
+                    const x = card.querySelector('.extra');
                     if (a && data.assumption) {
                         a.innerHTML = `<strong>Assumption:</strong> ${data.assumption}`;
                     }
                     if (e && data.evaluation) {
                         e.innerHTML = `<strong>Evaluation:</strong> ${data.evaluation}`;
+                    }
+                    if (x && data.extra) {
+                        x.innerHTML = data.extra;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- show parsed 'extra' details in each analysis section
- style .extra info boxes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b43bc76e4832895c7d28c21f92138