### PR TITLE
Add subcategory score display

### DIFF
--- a/analysis.css
+++ b/analysis.css
@@ -916,7 +916,7 @@ select.form-control {
   padding: var(--space-20);
 }
 
-.assumption, .evaluation, .extra {
+.assumption, .evaluation, .score-text {
   margin-bottom: var(--space-16);
   font-size: var(--font-size-base);
   line-height: var(--line-height-normal);
@@ -938,13 +938,16 @@ select.form-control {
   border-left: 3px solid var(--color-primary);
 }
 
-.extra {
-  color: var(--color-text-secondary);
+.score-text {
+  color: var(--color-text);
   padding: var(--space-12);
   background-color: var(--color-secondary);
   border-radius: var(--radius-base);
-  border-left: 3px solid var(--color-card-border);
+  border-left: 3px solid var(--color-success);
+  margin-bottom: var(--space-16);
+  font-weight: var(--font-weight-semibold);
 }
+
 
 .key-points {
   list-style: none;

--- a/analysis.html
+++ b/analysis.html
@@ -83,7 +83,7 @@
                     <div class="card-content">
                         <div class="assumption"></div>
                         <div class="evaluation"></div>
-                        <div class="extra"></div>
+                        <div class="score-text"></div>
                     </div>
                 </div>
 
@@ -108,7 +108,7 @@
                     <div class="card-content">
                         <div class="assumption"></div>
                         <div class="evaluation"></div>
-                        <div class="extra"></div>
+                        <div class="score-text"></div>
                     </div>
                 </div>
 
@@ -133,7 +133,7 @@
                     <div class="card-content">
                         <div class="assumption"></div>
                         <div class="evaluation"></div>
-                        <div class="extra"></div>
+                        <div class="score-text"></div>
                     </div>
                 </div>
 
@@ -158,7 +158,7 @@
                     <div class="card-content">
                         <div class="assumption"></div>
                         <div class="evaluation"></div>
-                        <div class="extra"></div>
+                        <div class="score-text"></div>
                     </div>
                 </div>
 
@@ -183,7 +183,7 @@
                     <div class="card-content">
                         <div class="assumption"></div>
                         <div class="evaluation"></div>
-                        <div class="extra"></div>
+                        <div class="score-text"></div>
                     </div>
                 </div>
             </div>

--- a/analysis.js
+++ b/analysis.js
@@ -239,7 +239,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 if (card) {
                     const a = card.querySelector('.assumption');
                     const e = card.querySelector('.evaluation');
-                    const x = card.querySelector('.extra');
+                    const st = card.querySelector('.score-text');
                     const sv = card.querySelector('.score-value');
                     const sb = card.querySelector('.score-bar-fill');
                     if (a && data.assumption) {
@@ -254,8 +254,8 @@ document.addEventListener('DOMContentLoaded', function() {
                     if (sb && data.score !== undefined) {
                         sb.setAttribute('data-score', data.score);
                     }
-                    if (x && data.extra) {
-                        x.innerHTML = data.extra;
+                    if (st && data.score !== undefined) {
+                        st.textContent = `Score: ${data.score}/10`;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- show score info in each analysis card
- remove unused `extra` sections
- style new score text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685b5050f79483289b1fdf58a14c13dc