### PR TITLE
Fix parsing of Score lines

### DIFF
--- a/analysis.js
+++ b/analysis.js
@@ -382,7 +382,7 @@ function parseAnalysisText(text) {
             }
             if (/^\*?score\*?/i.test(trimmed)) {
                 if (!sections[current]) sections[current] = {};
-                const m = trimmed.match(/score\s*:?\s*(\d+(?:\.\d+)?)/i);
+                const m = trimmed.match(/\*?score\*?\s*:?\s*(\d+(?:\.\d+)?)(?:\s*\/\s*10)?/i);
                 if (m) sections[current].score = parseFloat(m[1]);
                 return;
             }


### PR DESCRIPTION
## Summary
- allow `/10` notation when parsing score lines

## Testing
- `node - <<'EOF'
const parse=require('./parse.js');
const text=`### Sustainability Analysis of the Product
#### Materials
- *Assumption*: The table appears to be constructed from high-density polyethylene (HDPE) for the surface and metal (likely aluminum or steel) for the frame.
- *Evaluation*: HDPE is a recyclable plastic, and if the metal is also recyclable, it contributes positively to sustainability. However, if the plastic is not recycled or made from virgin materials, it would be less sustainable.
- *Score*: 6/10
`;
console.log(JSON.stringify(parse(text), null, 2));
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685b555b2d8c83288a522d4b3c1412cc