### PR TITLE
Improve mobile layout and headers

### DIFF
--- a/analysis.css
+++ b/analysis.css
@@ -833,9 +833,9 @@ select.form-control {
 .card-title {
   flex-grow: 1;
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: var(--space-16);
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-8);
 }
 
 .card-title h4 {
@@ -916,7 +916,8 @@ select.form-control {
   padding: var(--space-20);
 }
 
-.assumption, .evaluation, .score-text {
+.assumption,
+.evaluation {
   margin-bottom: var(--space-16);
   font-size: var(--font-size-base);
   line-height: var(--line-height-normal);
@@ -938,15 +939,6 @@ select.form-control {
   border-left: 3px solid var(--color-primary);
 }
 
-.score-text {
-  color: var(--color-text);
-  padding: var(--space-12);
-  background-color: var(--color-secondary);
-  border-radius: var(--radius-base);
-  border-left: 3px solid var(--color-success);
-  margin-bottom: var(--space-16);
-  font-weight: var(--font-weight-semibold);
-}
 
 
 .key-points {
@@ -1134,15 +1126,7 @@ select.form-control {
     padding: var(--space-16);
   }
   
-  .card-title {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: var(--space-8);
-  }
-  
-  .section-score {
-    align-self: flex-end;
-  }
+  /* Maintain header layout on mobile */
 }
 
 @media (max-width: 480px) {
@@ -1156,16 +1140,16 @@ select.form-control {
   }
   
   .card-header {
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-16);
+  }
+
+  .card-title {
+    width: auto;
     flex-direction: column;
     align-items: flex-start;
-    gap: var(--space-12);
-  }
-  
-  .card-title {
-    width: 100%;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
+    gap: var(--space-8);
   }
 }
 
@@ -1194,24 +1178,3 @@ select.form-control {
   outline-offset: 2px;
 }
 
-/* Top navigation header */
-.nav-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: var(--space-16);
-  background-color: var(--color-surface);
-}
-
-.nav-header a {
-  margin-left: var(--space-16);
-  text-decoration: none;
-  color: var(--color-text);
-  font-weight: var(--font-weight-medium);
-}
-
-.nav-header .logo {
-  margin-left: 0;
-  font-weight: var(--font-weight-bold);
-  color: var(--color-primary);
-}

--- a/analysis.html
+++ b/analysis.html
@@ -4,19 +4,37 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Product Sustainability Analysis</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link rel="stylesheet" href="analysis.css">
 </head>
 <body>
-    <header class="nav-header">
-        <a href="index.html" class="logo">EcoSnap</a>
-        <nav>
-            <a href="index.html">Home</a>
-            <a href="info.html#about">About Us</a>
-            <a href="info.html#why">Why</a>
-            <a href="info.html#blog">Blog</a>
-            <a href="green_agent.html">Green Agent</a>
+    <header class="w-full px-6 py-4 flex justify-between items-center shadow-sm md:px-8">
+        <div class="flex items-center gap-2">
+            <img src="assets/Camera%20log.png" alt="EcoSnap logo" class="w-6 h-6" />
+            <h1 class="text-xl font-bold text-green-600">EcoSnap</h1>
+        </div>
+        <button id="menu-btn" class="md:hidden text-gray-700 focus:outline-none">
+            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+        </button>
+        <nav class="hidden md:flex gap-6 text-sm font-medium items-center">
+            <a href="index.html" class="hover:text-green-600">Home</a>
+            <a href="info.html#about" class="hover:text-green-600">About Us</a>
+            <a href="info.html#why" class="hover:text-green-600">Why</a>
+            <a href="info.html#blog" class="hover:text-green-600">Blog</a>
+            <a href="green_agent.html" class="hover:text-green-600">Green Agent</a>
+            <span class="ml-4 text-xs text-gray-500">(5)</span>
         </nav>
     </header>
+    <div id="mobile-menu" class="hidden md:hidden px-6 pb-4 bg-white shadow-sm">
+        <a href="index.html" class="block py-2 text-sm hover:text-green-600">Home</a>
+        <a href="info.html#about" class="block py-2 text-sm hover:text-green-600">About Us</a>
+        <a href="info.html#why" class="block py-2 text-sm hover:text-green-600">Why</a>
+        <a href="info.html#blog" class="block py-2 text-sm hover:text-green-600">Blog</a>
+        <a href="green_agent.html" class="block py-2 text-sm hover:text-green-600">Green Agent</a>
+        <span class="block pt-2 text-xs text-gray-500">(5)</span>
+    </div>
     <div class="container">
         <!-- Header Section -->
         <header class="header">
@@ -83,7 +101,6 @@
                     <div class="card-content">
                         <div class="assumption"></div>
                         <div class="evaluation"></div>
-                        <div class="score-text"></div>
                     </div>
                 </div>
 
@@ -108,7 +125,6 @@
                     <div class="card-content">
                         <div class="assumption"></div>
                         <div class="evaluation"></div>
-                        <div class="score-text"></div>
                     </div>
                 </div>
 
@@ -133,7 +149,6 @@
                     <div class="card-content">
                         <div class="assumption"></div>
                         <div class="evaluation"></div>
-                        <div class="score-text"></div>
                     </div>
                 </div>
 
@@ -158,7 +173,6 @@
                     <div class="card-content">
                         <div class="assumption"></div>
                         <div class="evaluation"></div>
-                        <div class="score-text"></div>
                     </div>
                 </div>
 
@@ -183,7 +197,6 @@
                     <div class="card-content">
                         <div class="assumption"></div>
                         <div class="evaluation"></div>
-                        <div class="score-text"></div>
                     </div>
                 </div>
             </div>
@@ -201,6 +214,15 @@
         </footer>
     </div>
 
+    <script>
+        const menuBtn = document.getElementById('menu-btn');
+        const mobileMenu = document.getElementById('mobile-menu');
+        if (menuBtn && mobileMenu) {
+            menuBtn.addEventListener('click', () => {
+                mobileMenu.classList.toggle('hidden');
+            });
+        }
+    </script>
     <script src="analysis.js"></script>
 </body>
 </html>

--- a/analysis.js
+++ b/analysis.js
@@ -239,7 +239,6 @@ document.addEventListener('DOMContentLoaded', function() {
                 if (card) {
                     const a = card.querySelector('.assumption');
                     const e = card.querySelector('.evaluation');
-                    const st = card.querySelector('.score-text');
                     const sv = card.querySelector('.score-value');
                     const sb = card.querySelector('.score-bar-fill');
                     if (a && data.assumption) {
@@ -253,9 +252,6 @@ document.addEventListener('DOMContentLoaded', function() {
                     }
                     if (sb && data.score !== undefined) {
                         sb.setAttribute('data-score', data.score);
-                    }
-                    if (st && data.score !== undefined) {
-                        st.textContent = `Score: ${data.score}/10`;
                     }
                 }
             }

--- a/info.html
+++ b/info.html
@@ -5,8 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>EcoSnap Information</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
 </head>
-<body class="bg-white text-gray-800 font-sans">
+<body class="text-gray-800 font-sans">
   <header class="w-full px-6 py-4 flex justify-between items-center shadow-sm md:px-8">
     <div class="flex items-center gap-2">
       <img src="assets/Camera%20log.png" alt="EcoSnap logo" class="w-6 h-6" />


### PR DESCRIPTION
## Summary
- adjust analysis page header to match landing layout
- remove score text from dropdowns
- keep per-category score bars under titles
- fix mobile flex layout for icons
- apply site background to info page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b58d7d6308328a81b0c1f587f6a72