### PR TITLE
Apply unified layout styles

### DIFF
--- a/analysis.html
+++ b/analysis.html
@@ -5,11 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Product Sustainability Analysis</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+    <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="analysis.css">
 </head>
 <body>
-    <header class="w-full px-6 py-4 flex justify-between items-center shadow-sm md:px-8">
-        <div class="flex items-center gap-2">
+    <header class="site-header w-full px-6 py-4 flex justify-between items-center shadow-sm md:px-8">
+        <div class="logo flex items-center gap-2">
             <img src="assets/Camera%20log.png" alt="EcoSnap logo" class="w-6 h-6" />
             <h1 class="text-xl font-bold text-green-600">EcoSnap</h1>
         </div>

--- a/green_agent.html
+++ b/green_agent.html
@@ -4,18 +4,22 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Green Agent</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <header class="header">
-    <h1>Green Agent</h1>
+  <header class="site-header">
+    <div class="logo">
+      <i class="fa fa-leaf"></i> EcoSnap
+    </div>
     <nav>
       <a href="index.html">Home</a>
     </nav>
   </header>
 
   <main class="hero">
-    <h2>Your Sustainability Guide</h2>
+    <h1>Green Agent</h1>
+    <h2 class="subheading">Your Sustainability Guide</h2>
     <p>Green Agent scours the web for product details so you can make informed and eco‑friendly choices.</p>
     <div id="animation-area">
       <div id="stick-figure">

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>EcoSnap</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/info.html
+++ b/info.html
@@ -5,11 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>EcoSnap Information</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="text-gray-800 font-sans">
-  <header class="w-full px-6 py-4 flex justify-between items-center shadow-sm md:px-8">
-    <div class="flex items-center gap-2">
+  <header class="site-header w-full px-6 py-4 flex justify-between items-center shadow-sm md:px-8">
+    <div class="logo flex items-center gap-2">
       <img src="assets/Camera%20log.png" alt="EcoSnap logo" class="w-6 h-6" />
       <h1 class="text-xl font-bold text-green-600">EcoSnap</h1>
     </div>

--- a/landing-page.js
+++ b/landing-page.js
@@ -163,8 +163,8 @@ function LandingPage() {
   return (
     <div className="bg-white text-gray-800 font-sans">
       {/* Header */}
-      <header className="w-full px-6 py-4 flex justify-between items-center shadow-sm md:px-8">
-        <div className="flex items-center gap-2">
+      <header className="site-header w-full px-6 py-4 flex justify-between items-center shadow-sm md:px-8">
+        <div className="logo flex items-center gap-2">
           <img src="assets/Camera%20log.png" alt="EcoSnap logo" className="w-6 h-6" />
           <h1 className="text-xl font-bold text-green-600">EcoSnap</h1>
         </div>
@@ -198,12 +198,14 @@ function LandingPage() {
         </div>
       )}
 
-      {/* Hero Section */}
-      <section id="home" className="w-full bg-cover bg-center py-16 px-8 text-center text-white" style={{ backgroundImage: "url('assets/Main Background.png')" }}>
-        <div className="max-w-md mx-auto bg-black bg-opacity-50 p-6 rounded-xl">
-          <h2 className="text-2xl md:text-3xl font-bold mb-4">Make every choice count — for the planet and for the future</h2>
-          <p className="text-sm text-gray-300 mb-6">Use the power of AI to understand the green impact of your purchases</p>
-          <label className="block mb-4">
+
+      <header className="hero">
+        <div className="container">
+          <h1>Make Every Choice Count</h1>
+          <p className="subheading">For the planet and for the future</p>
+          <p className="tagline">Use the power of AI to understand the green impact of your purchases.</p>
+          <label className="snap-button">
+            <i className="fa fa-camera"></i> Snap
             <input
               type="file"
               accept="image/*"
@@ -211,11 +213,7 @@ function LandingPage() {
               onChange={handleSnap}
               className="hidden"
             />
-            <span className="cursor-pointer bg-green-600 w-full block text-white px-6 py-2 rounded-full text-sm font-medium hover:bg-green-700 text-center">
-              Snap
-            </span>
           </label>
-
           {imagePreview && (
             <>
               <img
@@ -233,11 +231,13 @@ function LandingPage() {
               <button onClick={handleScore} className="bg-white w-full text-green-700 px-6 py-2 rounded-full text-sm font-medium hover:bg-gray-200">
                 Score Me
               </button>
-              {result && <p className="text-sm text-white whitespace-pre-wrap mt-4">{result}</p>}
+              {result && (
+                <p className="text-sm text-white whitespace-pre-wrap mt-4">{result}</p>
+              )}
             </>
           )}
         </div>
-      </section>
+      </header>
 
       {/* Feature Highlights */}
       <section

--- a/style.css
+++ b/style.css
@@ -142,3 +142,83 @@ section {
   from { transform: translateX(0); }
   to { transform: translateX(200px); }
 }
+
+/* Shared layout styles */
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px;
+  background-color: #ffffff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: #2d9b57;
+}
+
+.logo i {
+  margin-right: 10px;
+  font-size: 1.8rem;
+}
+
+.hero {
+  background: linear-gradient(135deg, #d4f2d2, #f0fff4);
+  padding: 100px 20px;
+  text-align: center;
+  position: relative;
+  border-radius: 0 0 24px 24px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+  overflow: hidden;
+}
+
+.hero .container {
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.hero h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #1e4620;
+  margin-bottom: 0.5rem;
+}
+
+.hero .subheading {
+  font-size: 1.5rem;
+  font-weight: 500;
+  color: #317b3c;
+  margin-bottom: 1rem;
+}
+
+.hero .tagline {
+  font-size: 1rem;
+  color: #4d4d4d;
+  margin-bottom: 2rem;
+}
+
+.snap-button {
+  background-color: #2d9b57;
+  color: #fff;
+  border: none;
+  padding: 14px 28px;
+  font-size: 1rem;
+  border-radius: 30px;
+  cursor: pointer;
+  transition: background-color 0.3s ease, transform 0.2s ease;
+  font-weight: 600;
+  box-shadow: 0 8px 16px rgba(45, 155, 87, 0.25);
+}
+
+.snap-button:hover {
+  background-color: #228b4a;
+  transform: translateY(-2px);
+}
+
+.snap-button i {
+  margin-right: 8px;
+}


### PR DESCRIPTION
## Summary
- add shared layout styles in `style.css`
- include FontAwesome for icons on each page
- apply new header markup across pages
- revamp hero section in landing page using shared styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b5c560e4483288695fa4819f1e91d