### PR TITLE
Adjust analysis page colors

### DIFF
--- a/analysis.css
+++ b/analysis.css
@@ -1,9 +1,10 @@
 :root {
   /* Colors */
-  --color-background: rgba(252, 252, 249, 1);
-  --color-surface: rgba(255, 255, 253, 1);
-  --color-text: rgba(19, 52, 59, 1);
-  --color-text-secondary: rgba(98, 108, 113, 1);
+  /* Light theme palette tweaks */
+  --color-background: #ffffff;
+  --color-surface: #ffffff;
+  --color-text: #333333;
+  --color-text-secondary: #666666;
   --color-primary: rgba(33, 128, 141, 1);
   --color-primary-hover: rgba(29, 116, 128, 1);
   --color-primary-active: rgba(26, 104, 115, 1);
@@ -186,10 +187,10 @@
 }
 
 [data-color-scheme="light"] {
-  --color-background: rgba(252, 252, 249, 1);
-  --color-surface: rgba(255, 255, 253, 1);
-  --color-text: rgba(19, 52, 59, 1);
-  --color-text-secondary: rgba(98, 108, 113, 1);
+  --color-background: #ffffff;
+  --color-surface: #ffffff;
+  --color-text: #333333;
+  --color-text-secondary: #666666;
   --color-primary: rgba(33, 128, 141, 1);
   --color-primary-hover: rgba(29, 116, 128, 1);
   --color-primary-active: rgba(26, 104, 115, 1);
@@ -451,7 +452,7 @@ select.form-control {
 
 /* Card component */
 .card {
-  background-color: var(--color-surface);
+  background: linear-gradient(135deg, #e8f5e9 0%, #ffffff 100%);
   border-radius: var(--radius-lg);
   border: 1px solid var(--color-card-border);
   box-shadow: var(--shadow-sm);
@@ -822,7 +823,7 @@ select.form-control {
   gap: var(--space-16);
   padding: var(--space-20);
   border-bottom: 1px solid var(--color-card-border-inner);
-  background-color: var(--color-surface);
+  background-color: transparent;
 }
 
 .card-icon {


### PR DESCRIPTION
## Summary
- tweak light theme colors for the analysis page
- use gradient background on cards
- ensure card headers are transparent

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685b602c5f408328a7f8a24a887db400