### PR TITLE
Show image thumbnail on analysis page

### DIFF
--- a/analysis.css
+++ b/analysis.css
@@ -663,6 +663,13 @@ select.form-control {
   padding: var(--space-32) 0;
 }
 
+.header .thumbnail {
+  max-width: 150px;
+  margin: 0 auto var(--space-12);
+  border-radius: var(--radius-md);
+  display: block;
+}
+
 .header h1 {
   font-size: var(--font-size-4xl);
   color: var(--color-text);

--- a/analysis.html
+++ b/analysis.html
@@ -38,11 +38,8 @@
     <div class="container">
         <!-- Header Section -->
         <header class="header">
-            <h1>Product Sustainability Analysis</h1>
+            <img id="product-thumbnail" class="thumbnail" alt="Uploaded product preview">
             <h2 class="subtitle"></h2>
-            <p class="intro">
-                Comprehensive environmental impact assessment evaluating materials, manufacturing, design, and end-of-life considerations to determine the overall sustainability performance of this reusable drinkware product.
-            </p>
         </header>
 
         <!-- Overall Score Section -->

--- a/analysis.js
+++ b/analysis.js
@@ -214,8 +214,10 @@ class UserExperienceEnhancements {
 
 document.addEventListener('DOMContentLoaded', function() {
     const stored = sessionStorage.getItem('analysisResult');
+    let titleFromResult = '';
     if (stored) {
         const parsed = parseAnalysisText(stored);
+        titleFromResult = extractTitle(stored);
         const rationale = document.querySelector('.score-rationale');
         if (rationale) rationale.textContent = parsed.rationale || stored;
         if (parsed.score) {
@@ -252,11 +254,18 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
-    const productName = sessionStorage.getItem('productName');
+    const storedName = sessionStorage.getItem('productName');
+    const productName = titleFromResult || storedName;
     if (productName) {
         const subtitle = document.querySelector('.subtitle');
         if (subtitle) subtitle.textContent = productName;
         document.title = `Product Sustainability Analysis - ${productName}`;
+    }
+
+    const preview = sessionStorage.getItem('imagePreview');
+    if (preview) {
+        const img = document.getElementById('product-thumbnail');
+        if (img) img.src = preview;
     }
 
     const dashboard = new SustainabilityDashboard();
@@ -389,4 +398,12 @@ function parseAnalysisText(text) {
         }
     });
     return sections;
+}
+
+function extractTitle(text) {
+    const m = text.match(/Sustainability Analysis of(?: the)?\s+(.+)/i);
+    if (m) {
+        return m[1].trim();
+    }
+    return '';
 }

--- a/landing-page.js
+++ b/landing-page.js
@@ -92,7 +92,11 @@ function LandingPage() {
     if (file) {
       setImageFile(file);
       const reader = new FileReader();
-      reader.onloadend = () => setImagePreview(reader.result);
+      reader.onloadend = () => {
+        const dataUrl = reader.result;
+        setImagePreview(dataUrl);
+        sessionStorage.setItem('imagePreview', dataUrl);
+      };
       reader.readAsDataURL(file);
       const name = file.name ? file.name.replace(/\.[^/.]+$/, '') : 'Uploaded Product';
       sessionStorage.setItem('productName', name);


### PR DESCRIPTION
## Summary
- save uploaded image in sessionStorage on the landing page
- show thumbnail and product title on the analysis page header
- extract title from OpenAI results when possible
- style thumbnail in the header

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b6128e2508328a8c66457c8fe3787