### PR TITLE
Revise navigation and expand analysis sections

### DIFF
--- a/analysis.html
+++ b/analysis.html
@@ -13,28 +13,11 @@
             <img src="assets/Camera%20log.png" alt="EcoSnap logo" class="w-6 h-6" />
             <h1 class="text-xl font-bold text-green-600">EcoSnap</h1>
         </div>
-        <button id="menu-btn" class="md:hidden text-gray-700 focus:outline-none">
-            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-            </svg>
-        </button>
-        <nav class="hidden md:flex gap-6 text-sm font-medium items-center">
+        <nav class="flex gap-6 text-sm font-medium items-center">
             <a href="index.html" class="hover:text-green-600">Home</a>
-            <a href="info.html#about" class="hover:text-green-600">About Us</a>
-            <a href="info.html#why" class="hover:text-green-600">Why</a>
-            <a href="info.html#blog" class="hover:text-green-600">Blog</a>
-            <a href="green_agent.html" class="hover:text-green-600">Green Agent</a>
-            <span class="ml-4 text-xs text-gray-500">(5)</span>
+            <a href="#" class="hover:text-green-600">Login</a>
         </nav>
     </header>
-    <div id="mobile-menu" class="hidden md:hidden px-6 pb-4 bg-white shadow-sm">
-        <a href="index.html" class="block py-2 text-sm hover:text-green-600">Home</a>
-        <a href="info.html#about" class="block py-2 text-sm hover:text-green-600">About Us</a>
-        <a href="info.html#why" class="block py-2 text-sm hover:text-green-600">Why</a>
-        <a href="info.html#blog" class="block py-2 text-sm hover:text-green-600">Blog</a>
-        <a href="green_agent.html" class="block py-2 text-sm hover:text-green-600">Green Agent</a>
-        <span class="block pt-2 text-xs text-gray-500">(5)</span>
-    </div>
     <div class="container">
         <!-- Header Section -->
         <header class="header">
@@ -201,18 +184,15 @@
                 <p><strong>Scoring System:</strong> 10-point scale (1=Poor, 10=Excellent)</p>
                 <p><strong>Assessment Date:</strong> June 2025</p>
             </div>
+            <nav class="links">
+                <a href="info.html#about">About Us</a>
+                <a href="info.html#why">Why</a>
+                <a href="info.html#blog">Blog</a>
+                <a href="green_agent.html">Green Agent</a>
+            </nav>
         </footer>
     </div>
 
-    <script>
-        const menuBtn = document.getElementById('menu-btn');
-        const mobileMenu = document.getElementById('mobile-menu');
-        if (menuBtn && mobileMenu) {
-            menuBtn.addEventListener('click', () => {
-                mobileMenu.classList.toggle('hidden');
-            });
-        }
-    </script>
     <script src="analysis.js"></script>
 </body>
 </html>

--- a/analysis.js
+++ b/analysis.js
@@ -11,6 +11,7 @@ class SustainabilityDashboard {
         this.setupCardInteractions();
         this.animateProgressBars();
         this.setupAccessibility();
+        this.expandAllSections();
         setTimeout(() => {
             this.animateScoreOnLoad();
         }, 300);
@@ -152,6 +153,23 @@ class SustainabilityDashboard {
         if (card && !card.classList.contains('expanded')) {
             this.toggleCardExpansion(card);
         }
+    }
+
+    expandAllSections() {
+        this.analysisCards.forEach(card => {
+            if (!card.classList.contains('expanded')) {
+                card.classList.add('expanded');
+                const content = card.querySelector('.card-content');
+                if (content) {
+                    content.style.maxHeight = content.scrollHeight + 'px';
+                    content.style.opacity = '1';
+                    content.style.paddingTop = 'var(--space-20)';
+                    content.style.paddingBottom = 'var(--space-20)';
+                }
+                const expandBtn = card.querySelector('.expand-btn');
+                if (expandBtn) expandBtn.setAttribute('aria-expanded', 'true');
+            }
+        });
     }
 
     getAnalysisData() {

--- a/green_agent.html
+++ b/green_agent.html
@@ -9,8 +9,9 @@
 <body>
   <header class="header">
     <h1>Green Agent</h1>
-    <nav>
+    <nav class="flex gap-4">
       <a href="index.html">Home</a>
+      <a href="#">Login</a>
     </nav>
   </header>
 
@@ -32,7 +33,15 @@
   </main>
 
   <footer class="footer">
-    <p>&copy; 2024 GreenScore</p>
+    <div class="flex flex-col items-center space-y-2">
+      <nav class="flex gap-4 text-sm">
+        <a href="info.html#about">About Us</a>
+        <a href="info.html#why">Why</a>
+        <a href="info.html#blog">Blog</a>
+        <a href="green_agent.html">Green Agent</a>
+      </nav>
+      <p>&copy; 2024 GreenScore</p>
+    </div>
   </footer>
 
   <script src="green_agent.js"></script>

--- a/info.html
+++ b/info.html
@@ -13,28 +13,11 @@
       <img src="assets/Camera%20log.png" alt="EcoSnap logo" class="w-6 h-6" />
       <h1 class="text-xl font-bold text-green-600">EcoSnap</h1>
     </div>
-    <button id="menu-btn" class="md:hidden text-gray-700 focus:outline-none">
-      <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-      </svg>
-    </button>
-    <nav class="hidden md:flex gap-6 text-sm font-medium items-center">
+    <nav class="flex gap-6 text-sm font-medium items-center">
       <a href="index.html" class="hover:text-green-600">Home</a>
-      <a href="#about" class="hover:text-green-600">About Us</a>
-      <a href="#why" class="hover:text-green-600">Why</a>
-      <a href="#blog" class="hover:text-green-600">Blog</a>
-      <a href="green_agent.html" class="hover:text-green-600">Green Agent</a>
-      <span class="ml-4 text-xs text-gray-500">(5)</span>
+      <a href="#" class="hover:text-green-600">Login</a>
     </nav>
   </header>
-  <div id="mobile-menu" class="hidden md:hidden px-6 pb-4 bg-white shadow-sm">
-    <a href="index.html" class="block py-2 text-sm hover:text-green-600">Home</a>
-    <a href="#about" class="block py-2 text-sm hover:text-green-600">About Us</a>
-    <a href="#why" class="block py-2 text-sm hover:text-green-600">Why</a>
-    <a href="#blog" class="block py-2 text-sm hover:text-green-600">Blog</a>
-    <a href="green_agent.html" class="block py-2 text-sm hover:text-green-600">Green Agent</a>
-    <span class="block pt-2 text-xs text-gray-500">(5)</span>
-  </div>
 
   <main>
     <section id="about" class="w-full bg-green-50 py-16 px-8">
@@ -87,6 +70,12 @@
       <p class="text-sm text-gray-400 max-w-xs">
         Making everyday choices greener with the power of AI.
       </p>
+      <div class="flex flex-wrap justify-center gap-4 text-sm">
+        <a href="#about" class="hover:underline">About Us</a>
+        <a href="#why" class="hover:underline">Why</a>
+        <a href="#blog" class="hover:underline">Blog</a>
+        <a href="green_agent.html" class="hover:underline">Green Agent</a>
+      </div>
       <div class="flex gap-4">
         <a href="#" class="text-gray-400 hover:text-white text-xl"><i class="fab fa-twitter"></i></a>
         <a href="#" class="text-gray-400 hover:text-white text-xl"><i class="fab fa-instagram"></i></a>
@@ -95,14 +84,6 @@
       <p class="text-xs text-gray-500">© 2025 EcoSnap. All rights reserved.</p>
     </div>
   </footer>
-  <script>
-    const menuBtn = document.getElementById('menu-btn');
-    const mobileMenu = document.getElementById('mobile-menu');
-    if (menuBtn && mobileMenu) {
-      menuBtn.addEventListener('click', () => {
-        mobileMenu.classList.toggle('hidden');
-      });
-    }
-  </script>
+  
 </body>
 </html>

--- a/landing-page.js
+++ b/landing-page.js
@@ -70,22 +70,18 @@ Always return response in the example format.
 `;
 
 function LandingPage() {
-  const [menuOpen, setMenuOpen] = useState(false);
   const [imagePreview, setImagePreview] = useState(null);
   const [imageFile, setImageFile] = useState(null);
   const [apiKey, setApiKey] = useState("");
   const [result, setResult] = useState("");
 
-  // Navigation links used in the header
-  const navLinks = [
-    { text: "Home", href: "index.html" },
+  // Links moved to the footer
+  const footerLinks = [
     { text: "About Us", href: "info.html#about" },
     { text: "Why", href: "info.html#why" },
     { text: "Blog", href: "info.html#blog" },
     { text: "Green Agent", href: "green_agent.html" },
   ];
-  // Sum data for headers: total number of navigation sections
-  const headerCount = navLinks.length;
 
   const handleSnap = (event) => {
     const file = event.target.files[0];
@@ -172,35 +168,12 @@ function LandingPage() {
           <img src="assets/Camera%20log.png" alt="EcoSnap logo" className="w-6 h-6" />
           <h1 className="text-xl font-bold text-green-600">EcoSnap</h1>
         </div>
-        <button className="md:hidden text-gray-700 focus:outline-none" onClick={() => setMenuOpen(!menuOpen)}>
-          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-          </svg>
-        </button>
-        <nav className="hidden md:flex gap-6 text-sm font-medium items-center">
-          {navLinks.map((link) => (
-            <a key={link.text} href={link.href} className="hover:text-green-600">
-              {link.text}
-            </a>
-          ))}
-          <span className="ml-4 text-xs text-gray-500">({headerCount})</span>
+        <nav className="flex gap-6 text-sm font-medium items-center">
+          <a href="index.html" className="hover:text-green-600">Home</a>
+          <a href="#" className="hover:text-green-600">Login</a>
         </nav>
       </header>
 
-      {menuOpen && (
-        <div className="md:hidden px-6 pb-4 bg-white shadow-sm">
-          {navLinks.map((link) => (
-            <a
-              key={link.text}
-              href={link.href}
-              className="block py-2 text-sm hover:text-green-600"
-            >
-              {link.text}
-            </a>
-          ))}
-          <span className="block pt-2 text-xs text-gray-500">({headerCount})</span>
-        </div>
-      )}
 
       {/* Hero Section */}
       <section id="home" className="w-full bg-cover bg-center py-16 px-8 text-center text-white" style={{ backgroundImage: "url('assets/Main Background.png')" }}>
@@ -278,6 +251,13 @@ function LandingPage() {
           <p className="text-sm text-gray-400 max-w-xs">
             Making everyday choices greener with the power of AI.
           </p>
+          <div className="flex flex-wrap justify-center gap-4 text-sm">
+            {footerLinks.map((link) => (
+              <a key={link.text} href={link.href} className="hover:underline">
+                {link.text}
+              </a>
+            ))}
+          </div>
           <div className="flex gap-4">
             <a href="#" className="text-gray-400 hover:text-white text-xl"><i className="fab fa-twitter"></i></a>
             <a href="#" className="text-gray-400 hover:text-white text-xl"><i className="fab fa-instagram"></i></a>


### PR DESCRIPTION
## Summary
- keep all analysis categories expanded by default
- simplify headers with Home and Login links only
- move navigation items to footers
- clean up mobile menu code

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b65d8a9808328956f027a268b0c75