### PR TITLE
Add spinner when scoring

### DIFF
--- a/analysis.html
+++ b/analysis.html
@@ -8,6 +8,9 @@
     <link rel="stylesheet" href="main.css">
 </head>
 <body>
+    <div id="loading-overlay" class="loading-overlay" style="display:none;">
+        <div class="loader" aria-label="Loading"></div>
+    </div>
     <div id="header-placeholder"></div>
     <div class="container">
         <!-- Header Section -->

--- a/analysis.js
+++ b/analysis.js
@@ -231,6 +231,11 @@ class UserExperienceEnhancements {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
+    const overlay = document.getElementById('loading-overlay');
+    if (sessionStorage.getItem('showSpinner') === 'true' && overlay) {
+        overlay.style.display = 'flex';
+    }
+
     const stored = sessionStorage.getItem('analysisResult');
     let titleFromResult = '';
     if (stored) {
@@ -298,6 +303,11 @@ document.addEventListener('DOMContentLoaded', function() {
             console.log(`Dashboard loaded in ${Math.round(loadTime)}ms`);
         });
     }
+
+    if (overlay) {
+        overlay.style.display = 'none';
+    }
+    sessionStorage.removeItem('showSpinner');
 });
 
 window.addEventListener('resize', function() {

--- a/landing-page.js
+++ b/landing-page.js
@@ -99,11 +99,11 @@ function LandingPage() {
       return;
     }
 
+    sessionStorage.setItem('showSpinner', 'true');
     setLoading(true);
 
     const finalize = (text) => {
       setResult(text);
-      setLoading(false);
       sessionStorage.setItem('analysisResult', text);
       window.location.href = 'analysis.html';
     };

--- a/main.css
+++ b/main.css
@@ -1363,6 +1363,19 @@ select.form-control {
   animation: spin 1s linear infinite;
 }
 
+.loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
 @keyframes spin {
   0% {
     transform: rotate(0deg);


### PR DESCRIPTION
## Summary
- show loading overlay on analysis page
- keep spinner visible while navigating to results

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c91b323148328ba44748a1f5961bd