### PR TITLE
Add overlay spinner and image title parsing

### DIFF
--- a/analysis.js
+++ b/analysis.js
@@ -419,9 +419,12 @@ function parseAnalysisText(text) {
 }
 
 function extractTitle(text) {
-    const m = text.match(/Sustainability Analysis of(?: the)?\s+(.+)/i);
-    if (m) {
-        return m[1].trim();
+    const lines = text.split(/\n+/);
+    for (const line of lines) {
+        const m = line.match(/Sustainability Analysis of(?: the)?\s*(.+)/i);
+        if (m && m[1]) {
+            return m[1].replace(/[\*#]/g, '').trim();
+        }
     }
     return '';
 }

--- a/landing-page.js
+++ b/landing-page.js
@@ -159,6 +159,11 @@ function LandingPage() {
 
   return (
     <div className="bg-white text-gray-800 font-sans">
+      {loading && (
+        <div className="loading-overlay">
+          <div className="loader" aria-label="Loading"></div>
+        </div>
+      )}
 
 
       {/* Hero Section */}
@@ -196,11 +201,6 @@ function LandingPage() {
               <button onClick={handleScore} className="bg-white w-full text-green-700 px-6 py-2 rounded-full text-sm font-medium hover:bg-gray-200">
                 Score Me
               </button>
-              {loading && (
-                <div className="flex justify-center mt-4">
-                  <div className="loader" aria-label="Loading"></div>
-                </div>
-              )}
               {result && <p className="text-sm text-white whitespace-pre-wrap mt-4">{result}</p>}
             </>
           )}

--- a/main.css
+++ b/main.css
@@ -822,6 +822,9 @@ select.form-control {
   text-align: center;
   margin-bottom: var(--space-32);
   padding: var(--space-32) 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .header .thumbnail {
@@ -1355,11 +1358,11 @@ select.form-control {
 
 /* Simple spinner shown while scoring */
 .loader {
-  border: 4px solid #bbf7d0;
-  border-top: 4px solid #16a34a;
+  border: 6px solid #bbf7d0;
+  border-top: 6px solid #16a34a;
   border-radius: 50%;
-  width: 32px;
-  height: 32px;
+  width: 64px;
+  height: 64px;
   animation: spin 1s linear infinite;
 }
 


### PR DESCRIPTION
## Summary
- make spinner larger
- overlay loading spinner while scoring
- center header thumbnail and show product title
- parse product name from OpenAI result

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685c9531d3088328a001e786b96916b0