### PR TITLE
Adjust logo and tile spacing

### DIFF
--- a/components.js
+++ b/components.js
@@ -5,7 +5,7 @@ function insertHeader() {
 <header class="w-full px-8 py-4 flex justify-between items-center shadow-sm md:px-12">
   <div class="flex items-center gap-2">
     <img src="assets/Camera%20log.png" alt="EcoSnap logo" class="w-6 h-6" />
-    <h1 class="text-2xl font-bold text-green-600">EcoSnap</h1>
+    <h1 class="text-3xl font-bold text-green-600">EcoSnap</h1>
   </div>
   <nav class="flex gap-6 text-sm font-medium items-center">
     <a href="index.html" class="hover:text-green-600">Home</a>
@@ -24,7 +24,7 @@ function insertFooter() {
     <div class="flex flex-col items-center md:items-start gap-2 md:flex-1">
       <div class="flex items-center gap-2">
         <div class="w-5 h-5 bg-green-600 rounded-full"></div>
-        <h5 class="text-lg font-bold">EcoSnap</h5>
+        <h5 class="text-xl font-bold">EcoSnap</h5>
       </div>
       <p class="text-sm">Making everyday choices greener with the power of AI.</p>
     </div>

--- a/landing-page.js
+++ b/landing-page.js
@@ -179,7 +179,7 @@ function LandingPage() {
               onChange={handleSnap}
               className="hidden"
             />
-            <span className="cursor-pointer bg-green-600 w-full block text-white px-6 py-2 rounded-full text-sm font-medium hover:bg-green-700 text-center">
+            <span className="cursor-pointer bg-green-600 w-full block text-white px-8 py-3 rounded-full text-base font-medium hover:bg-green-700 text-center">
               Snap
             </span>
           </label>
@@ -209,7 +209,7 @@ function LandingPage() {
 
       {/* Feature Highlights */}
       <section
-        className="w-full bg-gray-50 py-16 px-4 bg-cover bg-center"
+        className="w-full bg-gray-50 py-16 px-8 bg-cover bg-center"
         style={{ backgroundImage: "url('assets/Main Background.png')" }}
       >
         <div className="max-w-6xl mx-auto grid md:grid-cols-3 gap-8">


### PR DESCRIPTION
## Summary
- enlarge EcoSnap brand text in header and footer
- enlarge Snap button text
- add more left and right padding around the feature tiles

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685c9eba8fac8328b09d6d3ab1c9a1db